### PR TITLE
Export namespace and fix req-id for end log

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -11,18 +11,18 @@ const logger = pino({
   }
 });
 
-const ns = createNamespace(NAMESPACE);
+const namespace = createNamespace(NAMESPACE);
 
 const getRequestId = () => {
-  return ns ? ns.get('requestId') : null;
+  return namespace ? namespace.get('requestId') : null;
 };
 
 const setRequestId = (id = uuid()) => {
-  ns.set('requestId', id);
+  namespace.set('requestId', id);
   return id;
 }
 
-const prependRequestId = msg => {
+const prependRequestId = (msg) => {
   const requestId = getRequestId();
   const prefix = requestId ? `[${requestId}] ` : '';
   return `${prefix}${msg}`;
@@ -42,24 +42,24 @@ const expressMiddleware = (req, res, next) => {
     `Started ${method} ${url} with params: ${params}, query: ${query}, body: ${body}.`
   );
   const begin = Date.now();
-  const foo = (error, response) => {
+  const foo = namespace.bind((error, response) => {
     const end = Date.now();
     const responseTime = error ? '-' : end - begin;
     const status = response.statusCode;
     info(`Ended ${method} ${url} with status: ${status} in ${responseTime} ms`);
-  };
+  });
   onFinished(res, foo);
   next();
 };
 
 const expressRequestIdMiddleware = (req, res, next) => {
-  ns.bindEmitter(req);
-  ns.bindEmitter(res);
-  return ns.run(() => {
+  namespace.bindEmitter(req);
+  namespace.bindEmitter(res);
+  return namespace.run(() => {
     const requestId = req.headers['x-request-id'] || uuid();
     setRequestId(requestId);
     next();
   });
 };
 
-module.exports = { logger: { ...logger, info, error }, expressMiddleware, expressRequestIdMiddleware, getRequestId, setRequestId };
+module.exports = { logger: { ...logger, info, error }, expressMiddleware, expressRequestIdMiddleware, getRequestId, setRequestId, namespace };

--- a/lib/index.js
+++ b/lib/index.js
@@ -22,7 +22,7 @@ const setRequestId = (id = uuid()) => {
   return id;
 }
 
-const prependRequestId = (msg) => {
+const prependRequestId = msg => {
   const requestId = getRequestId();
   const prefix = requestId ? `[${requestId}] ` : '';
   return `${prefix}${msg}`;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-wolox-logger",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "ExpressJS Wolox Logger",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

* Changed namespace variable name from `ns` to `namespace` and exported it.
* Bound end log function to the middleware context to fix some inconsistencies with it's requests ids.