### PR TITLE
Add namespace importing to readme and fix req-id for end log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Add `jest` tests.
 * Add `eslint` configuration.
 
+## 0.0.3
+* Change namespace variable name from `ns` to `namespace` and exported it.
+* Bind end log function to the middleware context to fix some inconsistencies with it's requests ids.
+
 ## 0.0.2
 * Add migration guide and publish first version.
 

--- a/README.md
+++ b/README.md
@@ -87,6 +87,16 @@ This, in conjunction with the basic logs will output:
 [2019-06-14 17:35:13.772 +0000] INFO  (17439 on my-pc.local): [GNc7JovB7] hello world
 [2019-06-14 17:35:13.772 +0000] ERROR (17439 on my-pc.local): [GNc7JovB7] something bad happened
 ```
+Note, that if you are using [Sequelize](http://docs.sequelizejs.com/), you need to configure it to use the logger's CLS namespace, otherwise the `requests ids` will not persist through `sequelize` promises. The same may apply to other frameworks.
+
+For `sequelize`, just set the namespace before creating a new `sequelize` instance:
+```
+const Sequelize = require('sequelize');
+const { namespace } = require('express-wolox-logger');
+
+Sequelize.useCLS(namespace);
+const sequelize = new Sequelize(...);
+```
 
 ### Advanced Usage
 The exported `expressRequestIdMiddleware` function takes one optional argument, [`options`](#options) and returns a `middleware`.

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -1,7 +1,7 @@
 const onFinished = require('on-finished');
 const shortid = require('shortid');
 
-const { ns, setRequestId } = require('./namespace');
+const { namespace, setRequestId } = require('./namespace');
 
 const expressMiddleware = opts => (req, res, next) => {
   const { method, params, query, body } = req;
@@ -10,21 +10,21 @@ const expressMiddleware = opts => (req, res, next) => {
 
   loggerFn(`Started ${url} ${method} with params:`, params || {}, 'query:', query || {}, 'body:', body || {});
   const begin = Date.now();
-  const onFinish = (error, response) => {
+  const onFinish = namespace.bind((error, response) => {
     const end = Date.now();
     const responseTime = error ? '-' : end - begin;
     const status = response.statusCode;
     loggerFn(`Ended ${method} ${url} with status: ${status} in ${responseTime} ms`);
-  };
+  });
   onFinished(res, onFinish);
   next();
 };
 
 const expressRequestIdMiddleware = opts => (req, res, next) => {
   const { headerName = 'x-request-id', idGenerator = shortid.generate } = opts || {};
-  ns.bindEmitter(req);
-  ns.bindEmitter(res);
-  return ns.run(() => {
+  namespace.bindEmitter(req);
+  namespace.bindEmitter(res);
+  return namespace.run(() => {
     const requestId = req.headers[headerName] || idGenerator();
     setRequestId(requestId);
     next();

--- a/lib/namespace.js
+++ b/lib/namespace.js
@@ -1,13 +1,13 @@
 const shortid = require('shortid');
 const { createNamespace } = require('cls-hooked');
 
-const ns = createNamespace(`express-wolox-logger:${shortid()}`);
+const namespace = createNamespace(`express-wolox-logger:${shortid()}`);
 
-const getRequestId = () => (ns ? ns.get('requestId') : null);
+const getRequestId = () => (namespace ? namespace.get('requestId') : null);
 
 const setRequestId = id => {
-  ns.set('requestId', id);
+  namespace.set('requestId', id);
   return id;
 };
 
-module.exports = { ns, getRequestId, setRequestId };
+module.exports = { namespace, getRequestId, setRequestId };

--- a/test/middlewares.spec.js
+++ b/test/middlewares.spec.js
@@ -4,16 +4,29 @@ const request = require('supertest');
 const { logger, expressMiddleware, expressRequestIdMiddleware, getRequestId } = require('..');
 
 describe('middlewares', () => {
-  const createServer = middleware =>
-    http.createServer((req, res) => {
-      middleware(req, res, () => {
-        const id = getRequestId();
-        if (id) {
-          res.setHeader('x-request-id', id);
-        }
-        res.end();
-      });
-    });
+  const chainMiddlewares = (req, res, end, middlewares) => {
+    const middleware = middlewares.shift();
+    if (!middlewares.length) {
+      return middleware(req, res, end);
+    }
+    return middleware(req, res, () => chainMiddlewares(req, res, end, middlewares));
+  };
+
+  const createServer = (...middlewares) =>
+    http.createServer((req, res) =>
+      chainMiddlewares(
+        req,
+        res,
+        () => {
+          const id = getRequestId();
+          if (id) {
+            res.setHeader('x-request-id', id);
+          }
+          res.end();
+        },
+        [...middlewares]
+      )
+    );
 
   const testUrl = '/test_url';
   const makeRequest = server => request(server).get(testUrl);
@@ -24,7 +37,7 @@ describe('middlewares', () => {
 
     const getLoggerCalledParams = num => loggerMock.mock.calls[num].map(JSON.stringify).join('');
 
-    test('should log when request start', done => {
+    test('should log when request starts', done => {
       makeRequest(server).end(() => {
         expect(getLoggerCalledParams(0)).toEqual(
           expect.stringMatching(/Started \/test_url GET with params:.*query:.*body.*/)
@@ -32,7 +45,7 @@ describe('middlewares', () => {
         done();
       });
     });
-    test('should log when request finish', done => {
+    test('should log when request finishes', done => {
       makeRequest(server).end(() => {
         expect(getLoggerCalledParams(1)).toEqual(
           expect.stringMatching(/Ended GET \/test_url with status: [2-5]+00 in [0-9]+ ms/)
@@ -58,6 +71,41 @@ describe('middlewares', () => {
           expect(res.header['x-request-id']).toBe('1');
           done();
         });
+    });
+  });
+
+  describe('express middleware + express id middleware', () => {
+    let requestIds = [];
+    jest.spyOn(logger, 'info').mockImplementation(() => {
+      requestIds.push(getRequestId());
+    });
+    const server = createServer(expressRequestIdMiddleware(), expressMiddleware({ loggerFn: logger.info }));
+
+    beforeEach(() => (requestIds = []));
+
+    test('should assign requestId sent in header and log correct request id when request starts', done => {
+      makeRequest(server)
+        .set({ 'x-request-id': 1 })
+        .end(() => {
+          expect(requestIds[0]).toBe('1');
+          done();
+        });
+    });
+
+    test('should assign requestId sent in header and log correct request id when request finishes', done => {
+      makeRequest(server)
+        .set({ 'x-request-id': 2 })
+        .end(() => {
+          expect(requestIds[1]).toBe('2');
+          done();
+        });
+    });
+
+    test('should assign a random requestId and both start and end logs should have it', done => {
+      makeRequest(server).end(() => {
+        expect(requestIds[0]).toEqual(requestIds[1]);
+        done();
+      });
     });
   });
 });


### PR DESCRIPTION
* Changed namespace variable name from `ns` to `namespace`.
* Added a short snippet on how to pass this namespace to Sequelize.
* Bound end log function to the middleware context to fix some inconsistencies with it's requests ids.
* Added test of the two middlewares combined.