### PR TITLE
Add basic benchmarks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Next release
+* Add basic benchmarks.
+
 ## 1.0.1
 * Add `obfuscateBody` and `obfuscatePlaceholder` option for secure sensitive data in body.
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,13 @@ const logger = createLogger({
 logger.foo('hello world');
 ```
 
+## Benchmarks
+There is a script included to excecute a benchmark test on the logger functionallity. The script name is `bench` and test `10*iterations` logger calls with different messages types and sizes to print.
+It can have none or one argument indicating the number of iterations to test, being `100` the default iterations value:
+```
+npm run bench [iterations]
+```
+
 # Middlewares
 ## Logs for request beginning and end
 We provide an ExpressJs middleware that automatically logs when a request starts and ends. Simply import it and use it like any other middleware.

--- a/lib/benchmarks.js
+++ b/lib/benchmarks.js
@@ -1,0 +1,77 @@
+'use strict';
+const bench = require('fastbench'),
+  pino = require('pino'),
+  { createLogger } = require('./loggers'),
+  nullLogger = createLogger({ options: pino.destination('/dev/null'), loggerOption: 'pino' }),
+  { type, platform, arch, release, cpus } = require('os');
+
+const stringExample = 'This is a string',
+  objectExample = { foo: 'bar', foo1: 'bar', foo2: 'bar', foo3: 'bar' },
+  deepObjExample = { ...require('../package.json'), level: 'info' },
+  longStringExample = JSON.stringify(require('../package.json')),
+  longDeepObjExample = { ...require('../package-lock.json'), level: 'info' },
+  reallyLongStringExample = JSON.stringify(require('../package-lock.json'));
+
+let iterations = 10;
+if (process.argv[2] && !isNaN(process.argv[2])) {
+  iterations = process.argv[2];
+}
+
+const times = 10;
+console.log(`Wolox logger benchmarks
+-------------------------------------------------------------
+To set the iterations number (default is 10) add a number argument to this bench call.
+Benchs:
+- simpleString is '${stringExample}'
+- simpleObject is ${JSON.stringify(objectExample)}
+- longString is the file package.json stringified
+- deepObject is the file package.json
+- reallyLongString is the file package-lock.json stringified
+- longDeepObject is the file package-lock.json
+-------------------------------------------------------------
+Run at: ${type()}/${platform()} ${arch()} ${release()} ~ ${cpus()[0].model} (cores/threads: ${cpus().length})
+10 logs, iterated ${iterations} times. Benched 2 times:`);
+const run = bench(
+  [
+    function simpleString(done) {
+      for (let i = 0; i < times; i++) {
+        nullLogger.info(stringExample);
+      }
+      setImmediate(done);
+    },
+    function simpleObject(done) {
+      for (let i = 0; i < times; i++) {
+        nullLogger.info(objectExample);
+      }
+      setImmediate(done);
+    },
+    function longString(done) {
+      for (let i = 0; i < times; i++) {
+        nullLogger.info(longStringExample);
+      }
+      setImmediate(done);
+    },
+    function deepObject(done) {
+      for (let i = 0; i < times; i++) {
+        nullLogger.info(deepObjExample);
+      }
+      setImmediate(done);
+    },
+    function reallyLongString(done) {
+      for (let i = 0; i < times; i++) {
+        nullLogger.info(reallyLongStringExample);
+      }
+      setImmediate(done);
+    },
+    function longDeepObj(done) {
+      for (let i = 0; i < times; i++) {
+        nullLogger.info(longDeepObjExample);
+      }
+      setImmediate(done);
+    }
+  ],
+  iterations
+);
+
+// run them two times
+run(run);

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint-fix": "eslint \"**/*.js\" --fix --ignore-pattern ./.eslintrc.js",
     "pretest": "npm run lint",
     "test": "jest --runInBand",
-    "coverage": "jest --coverage"
+    "coverage": "jest --coverage",
+    "bench": "node lib/benchmarks.js"
   },
   "repository": {
     "type": "git",
@@ -56,8 +57,10 @@
     "eslint-config-wolox": "^2.3.0",
     "eslint-config-wolox-node": "^1.0.0",
     "eslint-plugin-prettier": "^3.1.0",
+    "fastbench": "^1.0.1",
     "husky": "^2.3.0",
     "jest": "^24.8.0",
+    "os": "^0.1.1",
     "prettier": "^1.17.1",
     "prettier-eslint": "^8.8.2",
     "supertest": "^4.0.2"


### PR DESCRIPTION
## Summary

Add basic benchmarks as a script.
Based on Pino basic benchmark, using [fastbench](https://www.npmjs.com/package/fastbench) library.

I am not sure about the change versioning, but I think it is a minor version.

## Trello Card
https://trello.com/c/l4rgoHcT/58-agregar-benchmarks
