### PR TITLE
Logs on test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Next release
 * Add basic benchmarks.
+* Do not log when silentMode opts flag exist.
 
 ## 1.0.1
 * Add `obfuscateBody` and `obfuscatePlaceholder` option for secure sensitive data in body.

--- a/lib/loggers/index.js
+++ b/lib/loggers/index.js
@@ -7,6 +7,9 @@ const getRequestIdPrefix = () => {
   return requestId ? `[${requestId}] ` : '';
 };
 
+const isTesting = process.env.NODE_ENV && process.env.NODE_ENV.toLowerCase() === 'testing',
+  logOnTesting = !!process.env.LOG_ON_TEST;
+
 const createLogger = opts => {
   const { options, loggerOption = 'pino' } = opts || {};
   if (!loggerOptions.includes(loggerOption)) {
@@ -16,7 +19,8 @@ const createLogger = opts => {
   const { getLogger, getLogLevels } = require(`./${loggerOption}`);
   const logger = getLogger(options);
   const loggerWrapper = getLogLevels(logger).reduce((newLogger, logLevel) => {
-    newLogger[logLevel] = (...args) => logger[logLevel](getRequestIdPrefix(), ...args);
+    newLogger[logLevel] =
+      isTesting && !logOnTesting ? () => true : (...args) => logger[logLevel](getRequestIdPrefix(), ...args);
     return newLogger;
   }, {});
 


### PR DESCRIPTION
## Summary

Do not log when ~NODE_ENV env var is "testing" and LOG_ON_TEST env var do not exists~ silentMode opts flag exists.

## Trello Card

https://trello.com/c/qNDYg0Cs/116-deshabilitar-logs-con-nodeenvtesting