### PR TITLE
Add SonarCloud CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,16 @@ node_js:
   - "8.11.4"
 dist: trusty
 
+# TODO: Set organization and token to vinculate to SonarCloud and uncomment next 5 lines and the line 15 (sonar-scanner)
+# addons:
+#   sonarcloud:
+#     organization: "wolox"
+#     token:
+#       secure: "" # encrypted value of your token
+
 script:
-  - npm run test
+  - npm run coverage
+  # - sonar-scanner
 
 notifications:
   email: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 * Add basic benchmarks.
 * Do not log when silentMode opts flag exist.
 * Add Travis CI.
+* Add SonarCloud CI.
 
 ## 1.0.1
 * Add `obfuscateBody` and `obfuscatePlaceholder` option for secure sensitive data in body.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,17 @@
+# TODO: Set proyectKey, projectName and projectVersion according to Sonarcloud account  and uncomment next 4 lines
+# sonar.projectKey=wolox_express-wolox-logger
+# # this is the name and version displayed in the SonarCloud UI.
+# sonar.projectName=express-wolox-logger
+# sonar.projectVersion=1.0
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
+# This property is optional if sonar.modules is set. 
+sonar.sources=.
+
+# Encoding of the source code. Default is default system encoding
+#sonar.sourceEncoding=UTF-8
+
+# Tests
+sonar.tests=test/
+sonar.test.inclusions=**/*.spec.js
+sonar.javascript.lcov.reportPaths=coverage/lcov.info


### PR DESCRIPTION
## Summary
Add Sonarcloud CI.
It needs project configuration and changes at .travis.yml and sonar-project.properties, according to the following [doc](https://docs.google.com/document/d/1BZPIopvKby9KIc1UXxu63o7DV0iiBCsp3WBlYNL4osM/edit?usp=sharing).

## Trello Card
https://trello.com/c/SX436BFY/67-agregar-codeclimate