### PR TITLE
Add custom functions for start and finish messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,13 @@ The exported `expressRequestIdMiddleware` function takes one argument, [`options
 #### `options` (Object)
 
 ##### `loggerFn` (Function)
-Logger function used for start and end log actions.
+Logger function used for start and end log actions with the default message format.
+
+##### `startFn` (Function)
+Function used in start log actions, mainly for custom messages.
+
+##### `endFn` (Function)
+Function used in end log actions, mainly for custom messages.
 
 ##### `obfuscatePlaceholder` (String)
 Default: [SECURE]

--- a/lib/middlewares.js
+++ b/lib/middlewares.js
@@ -23,11 +23,39 @@ const getSecureBody = ({ params, url, method, body, placeholder }) => {
   }
 };
 
+const logStartMsg = ({ req, formattedBody, loggerFn, startFn }) => {
+  if (startFn) {
+    return startFn({ req, formattedBody });
+  }
+
+  const { method, params, query } = req;
+  const url = req.originalUrl || req.url;
+  return loggerFn(
+    `Started ${url} ${method} with params: %j query: %j body: %j`,
+    params || {},
+    query || {},
+    formattedBody || {}
+  );
+};
+
+const logEndMsg = ({ req, res, loggerFn, endFn, responseTime }) => {
+  if (endFn) {
+    return endFn({ req, res, responseTime });
+  }
+
+  const { method } = req;
+  const url = req.originalUrl || req.url;
+  const status = res.statusCode;
+  return loggerFn(`Ended ${method} ${url} with status: ${status} in ${responseTime} ms`);
+};
+
 const expressMiddleware = opts => {
   // TODO: add a check that all the config is safe
-  const { loggerFn, obfuscateBody = true, obfuscatePlaceholder = secure } = opts || {};
+  const { loggerFn, startFn, endFn, obfuscateBody = true, obfuscatePlaceholder = secure } = opts || {};
+  if (!loggerFn && (!startFn || !endFn)) throw Error('You need to define a loggerFn or a startFn and endFn');
+
   return (req, res, next) => {
-    const { method, params, query, body } = req;
+    const { method, body } = req;
     const url = req.originalUrl || req.url;
     const formattedBody = getSecureBody({
       params: obfuscateBody,
@@ -37,18 +65,12 @@ const expressMiddleware = opts => {
       placeholder: obfuscatePlaceholder
     });
 
-    loggerFn(
-      `Started ${url} ${method} with params: %j query: %j body: %j`,
-      params || {},
-      query || {},
-      formattedBody || {}
-    );
+    logStartMsg({ req, formattedBody, loggerFn, startFn });
     const begin = Date.now();
     const onFinish = namespace.bind((error, response) => {
       const end = Date.now();
       const responseTime = error ? '-' : end - begin;
-      const status = response.statusCode;
-      loggerFn(`Ended ${method} ${url} with status: ${status} in ${responseTime} ms`);
+      logEndMsg({ req, res: response, loggerFn, endFn, responseTime });
     });
     onFinished(res, onFinish);
     next();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-wolox-logger",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-wolox-logger",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "ExpressJS Wolox Logger",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Add custom functions startFn and endFn in order to customize the start and end messages if need 

## Known Issues

- N/A

## Trello Card

- N/A
