### PR TITLE
fix(pino): Spread log metadata

### DIFF
--- a/lib/loggers/pino.js
+++ b/lib/loggers/pino.js
@@ -7,6 +7,6 @@ module.exports = {
   getLogger: (options = {}) =>
     pino({
       ...options,
-      mixin: () => getLogMetadata()
+      mixin: () => ({ ...getLogMetadata() })
     })
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "express-wolox-logger",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-wolox-logger",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "ExpressJS Wolox Logger",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Summary

- Spread log metadata in order to avoid context mutation between logs, it's not necessary a deep clone because pino mutate only the root object

## Known Issues

- N/A

## Trello Card

- N/A
